### PR TITLE
Replace validator library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,13 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- used for json and xml validation -->
+        <dependency>
+            <groupId>com.atlassian.oai</groupId>
+            <artifactId>swagger-request-validator-core</artifactId>
+            <version>2.11.0</version>
+        </dependency>
+
+        <!-- used for OpenApi4jValidator -->
         <dependency>
             <groupId>org.openapi4j</groupId>
             <artifactId>openapi-operation-validator</artifactId>
@@ -100,26 +106,32 @@
             <groupId>org.openapi4j</groupId>
             <artifactId>openapi-parser</artifactId>
             <version>1.0.4</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.openapi4j</groupId>
             <artifactId>openapi-operation-servlet</artifactId>
             <version>1.0.4</version>
         </dependency>
+<!--        <dependency>-->
+<!--            <groupId>com.fasterxml.jackson.core</groupId>-->
+<!--            <artifactId>jackson-databind</artifactId>-->
+<!--            <version>2.11.2</version>-->
+<!--        </dependency>-->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
             <version>2.11.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-xml</artifactId>
-            <version>2.9.7</version>
-        </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20200518</version>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>2.11.2</version>
         </dependency>
 
         <!-- used for query params parsing -->
@@ -170,6 +182,7 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.12</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -118,11 +118,6 @@
             <artifactId>openapi-operation-servlet</artifactId>
             <version>1.0.4</version>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>com.fasterxml.jackson.core</groupId>-->
-<!--            <artifactId>jackson-databind</artifactId>-->
-<!--            <version>2.11.2</version>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -89,11 +89,39 @@
             <version>${camel.version}</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- used for json and xml validation -->
         <dependency>
-            <groupId>com.atlassian.oai</groupId>
-            <artifactId>swagger-request-validator-core</artifactId>
-            <version>2.11.0</version>
+            <groupId>org.openapi4j</groupId>
+            <artifactId>openapi-operation-validator</artifactId>
+            <version>1.0.4</version>
         </dependency>
+        <dependency>
+            <groupId>org.openapi4j</groupId>
+            <artifactId>openapi-parser</artifactId>
+            <version>1.0.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openapi4j</groupId>
+            <artifactId>openapi-operation-servlet</artifactId>
+            <version>1.0.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.11.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>2.9.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20200518</version>
+        </dependency>
+
         <!-- used for query params parsing -->
         <dependency>
             <groupId>org.springframework</groupId>
@@ -120,23 +148,34 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- used for logging -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>2.12.0</version>
         </dependency>
-
-        <!-- Log4j2 -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>2.11.2</version>
         </dependency>
-
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>2.11.2</version>
+        </dependency>
+
+        <!-- used for testing -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.12</version>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.16.1</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,26 @@
             <version>${camel.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.12.0</version>
+        </dependency>
+
+        <!-- Log4j2 -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.11.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.11.2</version>
+        </dependency>
+
     </dependencies>
 
 

--- a/src/main/java/com/ms3_inc/camel/extensions/rest/OpenApi4jValidator.java
+++ b/src/main/java/com/ms3_inc/camel/extensions/rest/OpenApi4jValidator.java
@@ -1,0 +1,139 @@
+package com.ms3_inc.camel.extensions.rest;
+
+/*-
+ * Copyright 2019-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.ms3_inc.camel.extensions.rest.exception.BadRequestException;
+import org.apache.camel.AsyncCallback;
+import org.apache.camel.Exchange;
+import org.apache.camel.support.AsyncProcessorSupport;
+import org.apache.camel.support.MessageHelper;
+import org.openapi4j.core.exception.ResolutionException;
+import org.openapi4j.core.validation.ValidationException;
+import org.openapi4j.core.validation.ValidationResults;
+import org.openapi4j.operation.validator.model.Request;
+import org.openapi4j.operation.validator.model.impl.Body;
+import org.openapi4j.operation.validator.model.impl.DefaultRequest;
+import org.openapi4j.operation.validator.validation.RequestValidator;
+import org.openapi4j.parser.OpenApi3Parser;
+import org.openapi4j.parser.model.v3.OpenApi3;
+import org.openapi4j.parser.model.v3.Server;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class OpenApi4jValidator extends AsyncProcessorSupport {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenApi4jValidator.class);
+    private static final XmlMapper XML_MAPPER = new XmlMapper();
+    private final RequestValidator openapi4jValidator;
+
+    public OpenApi4jValidator(String specPath) {
+        this(specPath, null);
+    }
+
+    public OpenApi4jValidator(String specPath, String basePath) {
+        OpenApi3 api = null;
+        try {
+            api = new OpenApi3Parser()
+                        .parse(new ClassPathResource(specPath).getFile(), false);
+        } catch (ResolutionException|ValidationException|IOException caughtExc) {
+            throw new IllegalArgumentException(caughtExc);
+        }
+
+        if (basePath != null) {
+            api.setServers(new ArrayList<Server>(){
+                {
+                    add(0, new Server().setUrl(basePath));
+                }
+            });
+        }
+
+        openapi4jValidator = new RequestValidator(api);
+    }
+
+    @Override
+    public boolean process(Exchange exchange, AsyncCallback callback) {
+        LOGGER.debug("Trying validation");
+
+        try {
+            openapi4jValidator.validate(fromExchange(exchange));
+        } catch (ValidationException e) {
+            ValidationResults results = e.results();
+            LOGGER.debug(e.results().toString());
+            exchange.setException(new BadRequestException(fromReport(results)));
+        } finally {
+            LOGGER.debug("Validating complete");
+            callback.done(true);
+        }
+
+        return true;
+    }
+
+    private static OperationResult fromReport(ValidationResults results) {
+        List<OperationResult.Message> answer = new ArrayList<>(1);
+        StringBuilder resultItems = new StringBuilder();
+
+        // separates the results into a "Validation failed." line for details and the rest for diagnostics
+        for (ValidationResults.ValidationItem result : results.items()) {
+            resultItems.append(result.message() + "\n");
+        }
+        answer.add(new OperationResult.Message(OperationResult.Level.ERROR, null, "Validation failed.", resultItems.toString()));
+
+        return new OperationResult(answer);
+    }
+
+    private static Request fromExchange(Exchange exchange) {
+        final Request.Method method = Request.Method.valueOf(exchange.getMessage().getHeader(Exchange.HTTP_METHOD, String.class));
+        final String path = exchange.getMessage().getHeader(Exchange.HTTP_URI, String.class);
+        final String query = exchange.getMessage().getHeader(Exchange.HTTP_QUERY, String.class);
+        final String body = MessageHelper.extractBodyAsString(exchange.getMessage());
+        final String contentType = exchange.getMessage().getHeader(Exchange.CONTENT_TYPE, String.class);
+        final DefaultRequest.Builder requestBuilder = new DefaultRequest.Builder(path, method);
+
+        if (!body.isEmpty()) {
+            if (contentType.equals("application/xml")) {
+                JsonNode node = XML_MAPPER.createObjectNode();
+
+                try {
+                    node = XML_MAPPER.readTree(body.getBytes());
+                } catch (IOException ioe) {
+                    LOGGER.error(ioe.getMessage());
+                }
+                requestBuilder.body(Body.from(node));
+            } else if (contentType.equals("application/json")) {
+                requestBuilder.body(Body.from(body));
+            }
+        }
+
+        for (Map.Entry<String, Object> header : exchange.getMessage().getHeaders().entrySet()) {
+            if (!header.getKey().startsWith("Camel") && header.getValue() instanceof String) {
+                requestBuilder.header(header.getKey(), (String) header.getValue());
+            }
+        }
+
+        requestBuilder.query(query);
+
+        return requestBuilder.build();
+    }
+}

--- a/src/main/java/com/ms3_inc/camel/extensions/rest/SwaggerRequestValidator.java
+++ b/src/main/java/com/ms3_inc/camel/extensions/rest/SwaggerRequestValidator.java
@@ -46,6 +46,13 @@ public class SwaggerRequestValidator extends AsyncProcessorSupport {
                 .build();
     }
 
+    public SwaggerRequestValidator(String specPath, String basePath) {
+        validator = OpenApiInteractionValidator
+                .createFor(specPath)
+                .withBasePathOverride(basePath)
+                .build();
+    }
+
     @Override
     public boolean process(Exchange exchange, AsyncCallback callback) {
         LOGGER.debug("Trying validation");

--- a/src/main/java/com/ms3_inc/camel/extensions/rest/SwaggerRequestValidator.java
+++ b/src/main/java/com/ms3_inc/camel/extensions/rest/SwaggerRequestValidator.java
@@ -16,41 +16,76 @@ package com.ms3_inc.camel.extensions.rest;
  * limitations under the License.
  */
 
-import com.atlassian.oai.validator.OpenApiInteractionValidator;
-import com.atlassian.oai.validator.model.Request;
-import com.atlassian.oai.validator.model.SimpleRequest;
-import com.atlassian.oai.validator.report.SimpleValidationReportFormat;
-import com.atlassian.oai.validator.report.ValidationReport;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.ms3_inc.camel.extensions.rest.exception.BadRequestException;
 import org.apache.camel.AsyncCallback;
-import org.apache.camel.CamelException;
 import org.apache.camel.Exchange;
 import org.apache.camel.support.AsyncProcessorSupport;
 import org.apache.camel.support.MessageHelper;
+import org.openapi4j.core.exception.ResolutionException;
+import org.openapi4j.core.validation.ValidationException;
+import org.openapi4j.core.validation.ValidationResults;
+import org.openapi4j.operation.validator.model.Request;
+import org.openapi4j.operation.validator.model.impl.Body;
+import org.openapi4j.operation.validator.model.impl.DefaultRequest;
+import org.openapi4j.operation.validator.validation.RequestValidator;
+import org.openapi4j.parser.OpenApi3Parser;
+import org.openapi4j.parser.model.v3.OpenApi3;
+import org.openapi4j.parser.model.v3.Server;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.core.io.ClassPathResource;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 public class SwaggerRequestValidator extends AsyncProcessorSupport {
-    private final Logger LOGGER = LoggerFactory.getLogger(getClass());
-    private final OpenApiInteractionValidator validator;
+    private final Logger LOGGER = LoggerFactory.getLogger(SwaggerRequestValidator.class);
+    private final RequestValidator openapi4jValidator;
+    private OpenApi3 api;
 
     public SwaggerRequestValidator(String specPath) {
-        validator = OpenApiInteractionValidator
-                .createFor(specPath)
-                .build();
+        api = null;
+
+        try {
+            api = new OpenApi3Parser()
+                    .parse(new ClassPathResource(specPath).getFile(), false);
+        } catch (ResolutionException re) {
+            LOGGER.error(re.getMessage());
+        } catch (ValidationException ve) {
+            LOGGER.error(ve.getMessage());
+        } catch (IOException ioe) {
+            LOGGER.error(ioe.getMessage());
+        }
+
+        openapi4jValidator = new RequestValidator(api);
     }
 
     public SwaggerRequestValidator(String specPath, String basePath) {
-        validator = OpenApiInteractionValidator
-                .createFor(specPath)
-                .withBasePathOverride(basePath)
-                .build();
+        api = null;
+
+        try {
+            api = new OpenApi3Parser()
+                    .parse(new ClassPathResource(specPath).getFile(), false);
+        } catch (ResolutionException re) {
+            LOGGER.error(re.getMessage());
+        } catch (ValidationException ve) {
+            LOGGER.error(ve.getMessage());
+        } catch (IOException ioe) {
+            LOGGER.error(ioe.getMessage());
+        }
+
+        api.setServers(new ArrayList<Server>(){
+            {
+                add(0, new Server().setUrl(basePath));
+            }
+        });
+
+        openapi4jValidator = new RequestValidator(api);
     }
 
     @Override
@@ -58,56 +93,66 @@ public class SwaggerRequestValidator extends AsyncProcessorSupport {
         LOGGER.debug("Trying validation");
 
         try {
-            ValidationReport report = validator.validateRequest(fromExchange(exchange));
-            if (report.hasErrors()) {
-                LOGGER.debug(report.toString());
-                exchange.setException(new BadRequestException(fromReport(report)));
-            }
-
-            LOGGER.debug("Validating complete");
-        } catch (Exception ex) {
-            exchange.setException(new CamelException(ex));
+            openapi4jValidator.validate(fromExchange(exchange));
+        } catch (ValidationException e) {
+            ValidationResults results = e.results();
+            LOGGER.debug(e.results().toString());
+            exchange.setException(new BadRequestException(fromReport(results)));
         } finally {
+            LOGGER.debug("Validating complete");
             callback.done(true);
         }
 
         return true;
     }
 
-    private static OperationResult fromReport(ValidationReport report) {
+    private static OperationResult fromReport(ValidationResults results) {
         List<OperationResult.Message> answer = new ArrayList<>(1);
+        StringBuilder resultItems = new StringBuilder();
 
-        // separates the report into a "Validation failed." line for details and the rest for diagnostics
-        String[] result = SimpleValidationReportFormat.getInstance().apply(report).split(System.lineSeparator(), 2);
-        answer.add(new OperationResult.Message(OperationResult.Level.ERROR, null, result[0], result[1]));
+        // separates the results into a "Validation failed." line for details and the rest for diagnostics
+        for (ValidationResults.ValidationItem result : results.items()) {
+            resultItems.append(result.message() + "\n");
+        }
+        answer.add(new OperationResult.Message(OperationResult.Level.ERROR, null, "Validation failed.", resultItems.toString()));
 
         return new OperationResult(answer);
     }
 
     private static Request fromExchange(Exchange exchange) {
+        final Logger LOGGER = LoggerFactory.getLogger(SwaggerRequestValidator.class);
+
         final Request.Method method = Request.Method.valueOf(exchange.getMessage().getHeader(Exchange.HTTP_METHOD, String.class));
         final String path = exchange.getMessage().getHeader(Exchange.HTTP_URI, String.class);
         final String query = exchange.getMessage().getHeader(Exchange.HTTP_QUERY, String.class);
         final String body = MessageHelper.extractBodyAsString(exchange.getMessage());
-        final SimpleRequest.Builder requestBuilder = new SimpleRequest.Builder(method, path);
+        final String contentType = exchange.getMessage().getHeader(Exchange.CONTENT_TYPE, String.class);
+        final DefaultRequest.Builder requestBuilder = new DefaultRequest.Builder(path, method);
 
         if (!body.isEmpty()) {
-            requestBuilder.withBody(body);
+            if (contentType.equals("application/xml")) {
+                XmlMapper xmlMapper = new XmlMapper();
+
+                JsonNode node = xmlMapper.createObjectNode();
+
+                try {
+                    node = xmlMapper.readTree(body.getBytes());
+                } catch (IOException ioe) {
+                    LOGGER.error(ioe.getMessage());
+                }
+                requestBuilder.body(Body.from(node));
+            } else if (contentType.equals("application/json")) {
+                requestBuilder.body(Body.from(body));
+            }
         }
 
         for (Map.Entry<String, Object> header : exchange.getMessage().getHeaders().entrySet()) {
             if (!header.getKey().startsWith("Camel") && header.getValue() instanceof String) {
-                requestBuilder.withHeader(header.getKey(), (String) header.getValue());
+                requestBuilder.header(header.getKey(), (String) header.getValue());
             }
         }
 
-        MultiValueMap<String, String> queryParams = UriComponentsBuilder.newInstance()
-                .query(query)
-                .build()
-                .getQueryParams();
-        for (Map.Entry<String, List<String>> queryParamEntry : queryParams.entrySet()) {
-            requestBuilder.withQueryParam(queryParamEntry.getKey(), queryParamEntry.getValue());
-        }
+        requestBuilder.query(query);
 
         return requestBuilder.build();
     }

--- a/src/main/java/com/ms3_inc/camel/extensions/rest/SwaggerRequestValidator.java
+++ b/src/main/java/com/ms3_inc/camel/extensions/rest/SwaggerRequestValidator.java
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/com/ms3_inc/camel/extensions/rest/exception/BadGatewayException.java
+++ b/src/main/java/com/ms3_inc/camel/extensions/rest/exception/BadGatewayException.java
@@ -18,20 +18,19 @@ package com.ms3_inc.camel.extensions.rest.exception;
 
 import com.ms3_inc.camel.extensions.rest.OperationResult;
 
+import java.util.Optional;
+
 public class BadGatewayException extends RestException {
-	public BadGatewayException(OperationResult result) {
-		super(result);
+	public BadGatewayException(OperationResult.Message message) {
+		super(message);
 	}
 
-	public BadGatewayException(String message, OperationResult result) {
-		super(message, result);
+	public BadGatewayException(Throwable cause, OperationResult.Message message) {
+		super(message, cause);
 	}
 
-	public BadGatewayException(String message, Throwable cause, OperationResult result) {
-		super(message, cause, result);
-	}
-
-	public BadGatewayException(Throwable cause, OperationResult result) {
-		super(cause, result);
+	@Override
+	public Optional<Integer> httpStatusCode() {
+		return Optional.of(502);
 	}
 }

--- a/src/main/java/com/ms3_inc/camel/extensions/rest/exception/BadRequestException.java
+++ b/src/main/java/com/ms3_inc/camel/extensions/rest/exception/BadRequestException.java
@@ -18,20 +18,19 @@ package com.ms3_inc.camel.extensions.rest.exception;
 
 import com.ms3_inc.camel.extensions.rest.OperationResult;
 
+import java.util.Optional;
+
 public class BadRequestException extends RestException {
-	public BadRequestException(OperationResult result) {
-		super(result);
+	public BadRequestException(OperationResult.Message message) {
+		super(message);
 	}
 
-	public BadRequestException(String message, OperationResult result) {
-		super(message, result);
+	public BadRequestException(Throwable cause, OperationResult.Message message) {
+		super(message, cause);
 	}
 
-	public BadRequestException(String message, Throwable cause, OperationResult result) {
-		super(message, cause, result);
-	}
-
-	public BadRequestException(Throwable cause, OperationResult result) {
-		super(cause, result);
+	@Override
+	public Optional<Integer> httpStatusCode() {
+		return Optional.of(400);
 	}
 }

--- a/src/main/java/com/ms3_inc/camel/extensions/rest/exception/GatewayTimeoutException.java
+++ b/src/main/java/com/ms3_inc/camel/extensions/rest/exception/GatewayTimeoutException.java
@@ -18,20 +18,19 @@ package com.ms3_inc.camel.extensions.rest.exception;
 
 import com.ms3_inc.camel.extensions.rest.OperationResult;
 
+import java.util.Optional;
+
 public class GatewayTimeoutException extends RestException {
-	public GatewayTimeoutException(OperationResult result) {
-		super(result);
+	public GatewayTimeoutException(OperationResult.Message message) {
+		super(message);
 	}
 
-	public GatewayTimeoutException(String message, OperationResult result) {
-		super(message, result);
+	public GatewayTimeoutException(Throwable cause, OperationResult.Message message) {
+		super(message, cause);
 	}
 
-	public GatewayTimeoutException(String message, Throwable cause, OperationResult result) {
-		super(message, cause, result);
-	}
-
-	public GatewayTimeoutException(Throwable cause, OperationResult result) {
-		super(cause, result);
+	@Override
+	public Optional<Integer> httpStatusCode() {
+		return Optional.of(504);
 	}
 }

--- a/src/main/java/com/ms3_inc/camel/extensions/rest/exception/InternalServerException.java
+++ b/src/main/java/com/ms3_inc/camel/extensions/rest/exception/InternalServerException.java
@@ -17,28 +17,20 @@ package com.ms3_inc.camel.extensions.rest.exception;
  */
 
 import com.ms3_inc.camel.extensions.rest.OperationResult;
-import org.apache.camel.CamelException;
 
 import java.util.Optional;
 
-public abstract class RestException extends CamelException {
-	private final OperationResult.Message message;
-
-	public RestException(OperationResult.Message message) {
-		super(message.toString());
-		this.message = message;
+public class InternalServerException extends RestException {
+	public InternalServerException(OperationResult.Message message) {
+		super(message);
 	}
 
-	public RestException(OperationResult.Message message, Throwable cause) {
-		super(message.toString(), cause);
-		this.message = message;
+	public InternalServerException(Throwable cause, OperationResult.Message message) {
+		super(message, cause);
 	}
 
-	public OperationResult.Message getOperationResultMessage() {
-		return message;
-	}
-
+	@Override
 	public Optional<Integer> httpStatusCode() {
-		return Optional.empty();
+		return Optional.of(500);
 	}
 }

--- a/src/main/java/com/ms3_inc/camel/extensions/rest/exception/NotFoundException.java
+++ b/src/main/java/com/ms3_inc/camel/extensions/rest/exception/NotFoundException.java
@@ -17,28 +17,20 @@ package com.ms3_inc.camel.extensions.rest.exception;
  */
 
 import com.ms3_inc.camel.extensions.rest.OperationResult;
-import org.apache.camel.CamelException;
 
 import java.util.Optional;
 
-public abstract class RestException extends CamelException {
-	private final OperationResult.Message message;
-
-	public RestException(OperationResult.Message message) {
-		super(message.toString());
-		this.message = message;
+public class NotFoundException extends RestException {
+	public NotFoundException(OperationResult.Message message) {
+		super(message);
 	}
 
-	public RestException(OperationResult.Message message, Throwable cause) {
-		super(message.toString(), cause);
-		this.message = message;
+	public NotFoundException(Throwable cause, OperationResult.Message message) {
+		super(message, cause);
 	}
 
-	public OperationResult.Message getOperationResultMessage() {
-		return message;
-	}
-
+	@Override
 	public Optional<Integer> httpStatusCode() {
-		return Optional.empty();
+		return Optional.of(404);
 	}
 }

--- a/src/main/java/com/ms3_inc/camel/extensions/rest/exception/NotImplementedException.java
+++ b/src/main/java/com/ms3_inc/camel/extensions/rest/exception/NotImplementedException.java
@@ -18,20 +18,19 @@ package com.ms3_inc.camel.extensions.rest.exception;
 
 import com.ms3_inc.camel.extensions.rest.OperationResult;
 
+import java.util.Optional;
+
 public class NotImplementedException extends RestException {
-	public NotImplementedException(OperationResult result) {
-		super(result);
+	public NotImplementedException(OperationResult.Message message) {
+		super(message);
 	}
 
-	public NotImplementedException(String message, OperationResult result) {
-		super(message, result);
+	public NotImplementedException(Throwable cause, OperationResult.Message message) {
+		super(message, cause);
 	}
 
-	public NotImplementedException(String message, Throwable cause, OperationResult result) {
-		super(message, cause, result);
-	}
-
-	public NotImplementedException(Throwable cause, OperationResult result) {
-		super(cause, result);
+	@Override
+	public Optional<Integer> httpStatusCode() {
+		return Optional.of(501);
 	}
 }

--- a/src/main/java/com/ms3_inc/camel/extensions/rest/exception/PreconditionFailedException.java
+++ b/src/main/java/com/ms3_inc/camel/extensions/rest/exception/PreconditionFailedException.java
@@ -18,20 +18,19 @@ package com.ms3_inc.camel.extensions.rest.exception;
 
 import com.ms3_inc.camel.extensions.rest.OperationResult;
 
+import java.util.Optional;
+
 public class PreconditionFailedException extends RestException {
-	public PreconditionFailedException(OperationResult result) {
-		super(result);
+	public PreconditionFailedException(OperationResult.Message message) {
+		super(message);
 	}
 
-	public PreconditionFailedException(String message, OperationResult result) {
-		super(message, result);
+	public PreconditionFailedException(Throwable cause, OperationResult.Message message) {
+		super(message, cause);
 	}
 
-	public PreconditionFailedException(String message, Throwable cause, OperationResult result) {
-		super(message, cause, result);
-	}
-
-	public PreconditionFailedException(Throwable cause, OperationResult result) {
-		super(cause, result);
+	@Override
+	public Optional<Integer> httpStatusCode() {
+		return Optional.of(412);
 	}
 }

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2019-2020 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <Configuration status="WARN" monitorInterval="30">
     <Properties>
         <Property name="LOG_PATTERN">

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -28,7 +28,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Logger name="com.ms3_inc.camel.extensions.rest.SwaggerRequestValidator" level="DEBUG" additivity="false">
+        <Logger name="com.ms3_inc.camel.extensions.rest.OpenApi4jValidator" level="DEBUG" additivity="false">
             <AppenderRef ref="ConsoleAppender" />
         </Logger>
         <Root level="INFO">

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" monitorInterval="30">
+    <Properties>
+        <Property name="LOG_PATTERN">
+            %d %p %processId --- [%t] %c : %m%n
+        </Property>
+    </Properties>
+    <Appenders>
+        <Console name="ConsoleAppender" target="SYSTEM_OUT" follow="true">
+            <PatternLayout pattern="${LOG_PATTERN}"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="com.ms3_inc.camel.extensions.rest.SwaggerRequestValidator" level="DEBUG" additivity="false">
+            <AppenderRef ref="ConsoleAppender" />
+        </Logger>
+        <Root level="INFO">
+            <AppenderRef ref="ConsoleAppender" />
+        </Root>
+    </Loggers>
+</Configuration>

--- a/src/test/java/com/ms3_inc/camel/extensions/rest/ValidatorTest.java
+++ b/src/test/java/com/ms3_inc/camel/extensions/rest/ValidatorTest.java
@@ -36,7 +36,6 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ValidatorTest extends CamelTestSupport {
-	private final String badRequestException = "com.ms3_inc.camel.extensions.rest.exception.BadRequestException";
 
 	@ParameterizedTest(name = "#{index} - Test with: {0}")
 	@MethodSource("validatorProvider")
@@ -98,7 +97,7 @@ class ValidatorTest extends CamelTestSupport {
 		mock.assertIsSatisfied();
 
 		String exceptionCaught = mock.getExchanges().get(0).getProperty("CamelExceptionCaught").toString();
-		assertThat(exceptionCaught).isEqualTo(badRequestException);
+		assertThat(exceptionCaught).contains("BadRequestException");
 	}
 
 	@ParameterizedTest(name = "#{index} - Test with: {0}")
@@ -131,12 +130,13 @@ class ValidatorTest extends CamelTestSupport {
 		mock.assertIsSatisfied();
 
 		String exceptionCaught = mock.getExchanges().get(0).getProperty("CamelExceptionCaught").toString();
-		assertThat(exceptionCaught).isEqualTo(badRequestException);
+		assertThat(exceptionCaught).contains("BadRequestException");
 	}
+
 
 	@ParameterizedTest(name = "#{index} - Test with: {0}")
 	@MethodSource("validatorProvider")
-	public void testValidHelloWithBasePath(String input) throws Exception {
+	public void testInvalidHelloHeaderWithBasePath(String input) throws Exception {
 		context.getRestConfiguration().setContextPath("/api");
 
 		RouteReifier.adviceWith(context.getRouteDefinitions().get(1), context, new AdviceWithRouteBuilder() {
@@ -154,16 +154,18 @@ class ValidatorTest extends CamelTestSupport {
 			}
 		});
 
-		MockEndpoint mock = getMockEndpoint("mock:result");
+		MockEndpoint mock = getMockEndpoint("mock:error");
 
 		CloseableHttpClient httpClient = HttpClientBuilder.create().build();
 		HttpUriRequest req = new HttpGet("http://localhost:9000/api/hello?bar-query=some");
-		req.addHeader("foo-header", "some");
 
 		httpClient.execute(req);
 
 		mock.expectedMessageCount(1);
 		mock.assertIsSatisfied();
+
+		String exceptionCaught = mock.getExchanges().get(0).getProperty("CamelExceptionCaught").toString();
+		assertThat(exceptionCaught).contains("BadRequestException");
 	}
 
 	@ParameterizedTest(name = "#{index} - Test with: {0}")
@@ -186,10 +188,10 @@ class ValidatorTest extends CamelTestSupport {
 			}
 		});
 
-		MockEndpoint mock = getMockEndpoint("mock:result");
+		MockEndpoint mock = getMockEndpoint("mock:error");
 
 		CloseableHttpClient httpClient = HttpClientBuilder.create().build();
-		HttpUriRequest req = new HttpGet("http://localhost:9000/api/hello?bar-query=some");
+		HttpUriRequest req = new HttpGet("http://localhost:9000/api/hello");
 		req.addHeader("foo-header", "some");
 
 		httpClient.execute(req);
@@ -229,7 +231,7 @@ class ValidatorTest extends CamelTestSupport {
 		mock.assertIsSatisfied();
 
 		String exceptionCaught = mock.getExchanges().get(0).getProperty("CamelExceptionCaught").toString();
-		assertThat(exceptionCaught).isEqualTo(badRequestException);
+		assertThat(exceptionCaught).contains("BadRequestException");
 	}
 
 	@Test
@@ -259,7 +261,7 @@ class ValidatorTest extends CamelTestSupport {
 		mock.assertIsSatisfied();
 
 		String exceptionCaught = mock.getExchanges().get(0).getProperty("CamelExceptionCaught").toString();
-		assertThat(exceptionCaught).isEqualTo(badRequestException);
+		assertThat(exceptionCaught).contains("BadRequestException");
 	}
 
 	@Test

--- a/src/test/java/com/ms3_inc/camel/extensions/rest/ValidatorTest.java
+++ b/src/test/java/com/ms3_inc/camel/extensions/rest/ValidatorTest.java
@@ -28,19 +28,32 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class SwaggerRequestValidatorTest extends CamelTestSupport {
+class ValidatorTest extends CamelTestSupport {
 	private final String badRequestException = "com.ms3_inc.camel.extensions.rest.exception.BadRequestException";
-	@Test
-	public void testValidHello() throws Exception {
+
+	@ParameterizedTest(name = "#{index} - Test with: {0}")
+	@MethodSource("validatorProvider")
+	public void testValidHello(String input) throws Exception {
 		RouteReifier.adviceWith(context.getRouteDefinitions().get(0), context, new AdviceWithRouteBuilder() {
 			@Override
 			public void configure() throws Exception {
-				interceptFrom()
-						.process(new SwaggerRequestValidator("api.yaml"))
-				;
+				if (input.equals("openapi4j")) {
+					interceptFrom()
+							.process(new OpenApi4jValidator("api.yaml"))
+					;
+				} else {
+					interceptFrom()
+							.process(new SwaggerRequestValidator("api.yaml"))
+					;
+				}
+
 			}
 		});
 
@@ -56,14 +69,21 @@ class SwaggerRequestValidatorTest extends CamelTestSupport {
 		mock.assertIsSatisfied();
 	}
 
-	@Test
-	public void testInvalidHelloHeader() throws Exception {
+	@ParameterizedTest(name = "#{index} - Test with: {0}")
+	@MethodSource("validatorProvider")
+	public void testInvalidHelloHeader(String input) throws Exception {
 		RouteReifier.adviceWith(context.getRouteDefinitions().get(0), context, new AdviceWithRouteBuilder() {
 			@Override
 			public void configure() throws Exception {
-				interceptFrom()
-						.process(new SwaggerRequestValidator("api.yaml"))
-				;
+				if (input.equals("openapi4j")) {
+					interceptFrom()
+							.process(new OpenApi4jValidator("api.yaml"))
+					;
+				} else {
+					interceptFrom()
+							.process(new SwaggerRequestValidator("api.yaml"))
+					;
+				}
 			}
 		});
 
@@ -81,14 +101,21 @@ class SwaggerRequestValidatorTest extends CamelTestSupport {
 		assertThat(exceptionCaught).isEqualTo(badRequestException);
 	}
 
-	@Test
-	public void testInvalidHelloQuery() throws Exception {
+	@ParameterizedTest(name = "#{index} - Test with: {0}")
+	@MethodSource("validatorProvider")
+	public void testInvalidHelloQuery(String input) throws Exception {
 		RouteReifier.adviceWith(context.getRouteDefinitions().get(0), context, new AdviceWithRouteBuilder() {
 			@Override
 			public void configure() throws Exception {
-				interceptFrom()
-						.process(new SwaggerRequestValidator("api.yaml"))
-				;
+				if (input.equals("openapi4j")) {
+					interceptFrom()
+							.process(new OpenApi4jValidator("api.yaml"))
+					;
+				} else {
+					interceptFrom()
+							.process(new SwaggerRequestValidator("api.yaml"))
+					;
+				}
 			}
 		});
 
@@ -107,16 +134,23 @@ class SwaggerRequestValidatorTest extends CamelTestSupport {
 		assertThat(exceptionCaught).isEqualTo(badRequestException);
 	}
 
-	@Test
-	public void testValidHelloWithBasePath() throws Exception {
+	@ParameterizedTest(name = "#{index} - Test with: {0}")
+	@MethodSource("validatorProvider")
+	public void testValidHelloWithBasePath(String input) throws Exception {
 		context.getRestConfiguration().setContextPath("/api");
 
 		RouteReifier.adviceWith(context.getRouteDefinitions().get(1), context, new AdviceWithRouteBuilder() {
 			@Override
 			public void configure() throws Exception {
-				interceptFrom()
-						.process(new SwaggerRequestValidator("api.yaml", "/api"))
-				;
+				if (input.equals("openapi4j")) {
+					interceptFrom()
+							.process(new OpenApi4jValidator("api.yaml", "/api"))
+					;
+				} else {
+					interceptFrom()
+							.process(new SwaggerRequestValidator("api.yaml", "/api"))
+					;
+				}
 			}
 		});
 
@@ -132,16 +166,23 @@ class SwaggerRequestValidatorTest extends CamelTestSupport {
 		mock.assertIsSatisfied();
 	}
 
-	@Test
-	public void testInvalidHelloWithBasePath() throws Exception {
+	@ParameterizedTest(name = "#{index} - Test with: {0}")
+	@MethodSource("validatorProvider")
+	public void testInvalidHelloWithBasePath(String input) throws Exception {
 		context.getRestConfiguration().setContextPath("/api");
 
 		RouteReifier.adviceWith(context.getRouteDefinitions().get(1), context, new AdviceWithRouteBuilder() {
 			@Override
 			public void configure() throws Exception {
-				interceptFrom()
-						.process(new SwaggerRequestValidator("api.yaml", "/api"))
-				;
+				if (input.equals("openapi4j")) {
+					interceptFrom()
+							.process(new OpenApi4jValidator("api.yaml", "/api"))
+					;
+				} else {
+					interceptFrom()
+							.process(new SwaggerRequestValidator("api.yaml", "/api"))
+					;
+				}
 			}
 		});
 
@@ -157,14 +198,21 @@ class SwaggerRequestValidatorTest extends CamelTestSupport {
 		mock.assertIsSatisfied();
 	}
 
-	@Test
-	public void testInvalidGreetingJSON() throws Exception {
+	@ParameterizedTest(name = "#{index} - Test with: {0}")
+	@MethodSource("validatorProvider")
+	public void testInvalidGreetingJSON(String input) throws Exception {
 		RouteReifier.adviceWith(context.getRouteDefinitions().get(0), context, new AdviceWithRouteBuilder() {
 			@Override
 			public void configure() throws Exception {
-				interceptFrom()
-						.process(new SwaggerRequestValidator("api.yaml"))
-				;
+				if (input.equals("openapi4j")) {
+					interceptFrom()
+							.process(new OpenApi4jValidator("api.yaml"))
+					;
+				} else {
+					interceptFrom()
+							.process(new SwaggerRequestValidator("api.yaml"))
+					;
+				}
 			}
 		});
 
@@ -190,7 +238,7 @@ class SwaggerRequestValidatorTest extends CamelTestSupport {
 			@Override
 			public void configure() throws Exception {
 				interceptFrom()
-						.process(new SwaggerRequestValidator("api.yaml"))
+						.process(new OpenApi4jValidator("api.yaml"))
 				;
 			}
 		});
@@ -220,7 +268,7 @@ class SwaggerRequestValidatorTest extends CamelTestSupport {
 			@Override
 			public void configure() throws Exception {
 				interceptFrom()
-						.process(new SwaggerRequestValidator("api.yaml"))
+						.process(new OpenApi4jValidator("api.yaml"))
 				;
 			}
 		});
@@ -239,6 +287,10 @@ class SwaggerRequestValidatorTest extends CamelTestSupport {
 
 		mock.expectedMessageCount(1);
 		mock.assertIsSatisfied();
+	}
+
+	static Stream<String> validatorProvider() {
+		return Stream.of("openapi4j", "swagger");
 	}
 
 	@Override

--- a/src/test/resources/api.yaml
+++ b/src/test/resources/api.yaml
@@ -28,6 +28,8 @@ paths:
                     type: string
   /greeting:
     post:
+      security:
+        - bearerAuth: []
       requestBody:
         content:
           application/json:
@@ -38,6 +40,16 @@ paths:
               properties:
                 caller:
                   type: string
+          application/xml:
+            schema:
+              type: object
+              required:
+                - caller
+              properties:
+                caller:
+                  type: string
+              xml:
+                name: greeting
       responses:
         200:
           description: greeting response
@@ -48,3 +60,8 @@ paths:
                 properties:
                   greetings:
                     type: string
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer


### PR DESCRIPTION
Replace swagger-request-validator with openapi4j for xml validation functionality

    - Update spec with xml request schema
    - Refactor pom: organize/add comments, add openapi4j, remove swagger-request-validator, add dependencies for tests
    - Replace validator with openapi4j parser, validator, and converting xml to a JsonNode
    - Reorganize tests, add xml tests, add assertJ validation for post requests to further assert that the correct exception occurred